### PR TITLE
Fix setting cookie on authenticate call

### DIFF
--- a/components/BookDetails.vue
+++ b/components/BookDetails.vue
@@ -140,7 +140,11 @@ export default {
       const cacheStorage = await caches.open(cacheName)
 
       await Promise.all(this.details.files.map((file) => {
-        return cacheStorage.add(this.$store.getters['app/getFileUrl'](file.path))
+        const req = new Request(this.$store.getters['app/getFileUrl'](file.path),
+          {
+            credentials: 'include'
+          })
+        return cacheStorage.add(req)
       }))
       this.downloading = false
       this.cached = true

--- a/store/app/actions.js
+++ b/store/app/actions.js
@@ -51,6 +51,8 @@ export function login (context, data) {
         const bodyFormData = 'secret=' + encodeURIComponent(thesecret)
         fetch(data.server + 'authenticate', {
           method: 'POST',
+          mode: 'cors',
+          credentials: 'include', // this one is essential - use it on all fetch requests
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded'
           },


### PR DESCRIPTION
For fetch to work properly additional options must be added -
especially credentials: 'include' and mode mode:'cors'.